### PR TITLE
Ability to pass specific xmlns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-soap-plus",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "SOAP Client for Node Red",
     "main": "index.js",
     "scripts": {
@@ -29,6 +29,10 @@
         {
             "name": "Michael Qiu",
             "email": "mqiu@sensetecnic.com"
+        },
+        {
+            "name": "Andre Guerra",
+            "email": "andre.guerra@airship.co.uk"
         }
     ],
     "license": "MIT",

--- a/soap-node-plus.html
+++ b/soap-node-plus.html
@@ -47,6 +47,7 @@
             <li>You can have <b>msg.server</b> to overwrite the WSDL address. This only works with WSDL server with no authentication method.</li>
             <li>You can have <b>msg.options</b> to add in options to the SOAP request.</li>
             <li>You can have <b>msg.headers</b> to add in headers for the SOAP request.</li>
+            <li>You can have <b>msg.headersOptions</b> to add in headersOptions: name, namespace and xmlns.</li>
             <li>You can feed in <b>msg.payload.&lt;parameters&gt;</b> to feed in the parameters you need.</li>
 
         </ul>

--- a/soap-node-plus.js
+++ b/soap-node-plus.js
@@ -40,7 +40,11 @@ module.exports = function (RED) {
                     }
                     node.status({fill: "yellow", shape: "dot", text: "SOAP Request..."});
                     if(msg.headers){
-                        client.addSoapHeader(msg.headers);
+                        if (msg.headersOptions){
+                            client.addSoapHeader(msg.headers, msg.headersOptions.name, msg.headersOptions.nameSpace, msg.headersOptions.xmlns);
+                        } else {
+                            client.addSoapHeader(msg.header);
+                        }
                     }
 
                     if(client.hasOwnProperty(node.method)){


### PR DESCRIPTION
Added ability to pass specific xmlns.

Use `msg.headersOptions` with params : name, nameSpace, xmlns