### PR TITLE
Ability to error messages continue the flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+### 1.2.0 : Send error message on payload (09-12-2021)
+- Added error output
+- Send error on new output with `node.send()` instead of `node.error()`
+- Added CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-soap-plus",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "SOAP Client for Node Red",
     "main": "index.js",
     "scripts": {

--- a/soap-node-plus.html
+++ b/soap-node-plus.html
@@ -4,7 +4,8 @@
         icon: "white-globe.png",
         color: "#a6bbcf",
         inputs: 1,
-        outputs: 1,
+        outputs: 2,
+        outputLabels: ['success', 'error'],
         defaults: {
             name: { value: "" },
             topic: { value: "" },


### PR DESCRIPTION
- Added error output
- Send error on new output with `node.send()` instead of `node.error()`
- Added CHANGELOG.md